### PR TITLE
Test bundle switch

### DIFF
--- a/fixtures/lib/requireJquery.js
+++ b/fixtures/lib/requireJquery.js
@@ -1,0 +1,3 @@
+var $ = require('jquery');
+
+module.exports = $;

--- a/lib/index.js
+++ b/lib/index.js
@@ -187,6 +187,7 @@ module.exports = function (options) {
         })
         .catch(function (err) {
           err.statusCode = 500;
+          err.stack = err.message;
           next(err);
         });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,10 @@ module.exports = function (options) {
     buildFlags: {}
   }, options || {});
 
-  options.buildFlags = extend({ dev: true }, options.buildFlags);
+  options.buildFlags = extend({
+    dev: true,
+    normalize: true
+  }, options.buildFlags);
 
   var absoluteConfigUrl;
 

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -88,135 +88,273 @@ function runtests(getApp, description) {
     });
 
     describe('when requesting files with the systemjs accepts header', function () {
-      it('should compile javascript', function () {
-        return expect(getApp(), 'to yield exchange', {
-          request: {
-            url: '/default.js',
-            headers: {
-              accept: 'application/x-es-module */*'
-            }
-          },
-          response: {
-            statusCode: 200,
-            headers: {
-              'Content-Type': /^application\/javascript/
+      describe('with bundling disabled', function () {
+        it('should compile javascript', function () {
+          return expect(getApp(), 'to yield exchange', {
+            request: {
+              url: '/default.js',
+              headers: {
+                accept: 'application/x-es-module */*'
+              }
             },
-            body: expect.it('to begin with', 'System.registerDynamic([]').and('to contain', 'console.log(\'hello world\');\n')
-          }
-        });
-      });
-
-      it('should handle commonjs', function () {
-        return expect(getApp(), 'to yield exchange', {
-          request: {
-            url: '/lib/stringExport.js',
-            headers: {
-              accept: 'application/x-es-module */*'
+            response: {
+              statusCode: 200,
+              headers: {
+                'Content-Type': /^application\/javascript/
+              },
+              body: expect.it('to begin with', 'System.registerDynamic([]').and('to contain', 'console.log(\'hello world\');\n')
             }
-          },
-          response: {
-            statusCode: 200,
-            headers: {
-              'Content-Type': /^application\/javascript/
+          });
+        });
+
+        it('should handle commonjs', function () {
+          return expect(getApp(), 'to yield exchange', {
+            request: {
+              url: '/lib/stringExport.js',
+              headers: {
+                accept: 'application/x-es-module */*'
+              }
             },
-            body: expect.it('to begin with', 'System.registerDynamic([]').and('to contain', 'module.exports = \'foo\';\n')
-          }
-        });
-      });
-
-      it('should handle commonjs imports', function () {
-        return expect(getApp(), 'to yield exchange', {
-          request: {
-            url: '/lib/requireWorking.js',
-            headers: {
-              accept: 'application/x-es-module */*'
+            response: {
+              statusCode: 200,
+              headers: {
+                'Content-Type': /^application\/javascript/
+              },
+              body: expect.it('to begin with', 'System.registerDynamic([]').and('to contain', 'module.exports = \'foo\';\n')
             }
-          },
-          response: {
-            statusCode: 200,
-            headers: {
-              'Content-Type': /^application\/javascript/
+          });
+        });
+
+        it('should handle commonjs imports', function () {
+          return expect(getApp(), 'to yield exchange', {
+            request: {
+              url: '/lib/requireWorking.js',
+              headers: {
+                accept: 'application/x-es-module */*'
+              }
             },
-            body: expect.it('to begin with', 'System.registerDynamic(["./stringExport"]').and('to contain', 'var foo = $__require(\'./stringExport\');\n  module.exports = {foo: foo};\n')
-          }
-        });
-      });
-
-      it('should pass uncompileable errors through to the client', function () {
-        return expect(getApp(), 'to yield exchange', {
-          request: {
-            url: '/lib/broken.js',
-            headers: {
-              accept: 'application/x-es-module */*'
+            response: {
+              statusCode: 200,
+              headers: {
+                'Content-Type': /^application\/javascript/
+              },
+              body: expect.it('to begin with', 'System.registerDynamic(["./stringExport"]').and('to contain', 'var foo = $__require(\'./stringExport\');\n  module.exports = {foo: foo};\n')
             }
-          },
-          response: {
-            errorPassedToNext: /Unterminated String Literal/,
-            statusCode: 500
-          }
+          });
         });
-      });
 
-      it('should handle commonjs imports of broken assets', function () {
-        return expect(getApp(), 'to yield exchange', {
-          request: {
-            url: '/lib/requireBroken.js',
-            headers: {
-              accept: 'application/x-es-module */*'
-            }
-          },
-          response: {
-            statusCode: 200,
-            headers: {
-              'Content-Type': /^application\/javascript/
+        it('should pass uncompileable errors through to the client', function () {
+          return expect(getApp(), 'to yield exchange', {
+            request: {
+              url: '/lib/broken.js',
+              headers: {
+                accept: 'application/x-es-module */*'
+              }
             },
-            body: expect.it('to begin with', 'System.registerDynamic(["./broken"]').and('to contain', 'var foo = $__require(\'./broken\');\n  module.exports = {foo: foo};\n')
-          }
-        });
-      });
-
-      it('should handle jspm modules', function () {
-        return expect(getApp(), 'to yield exchange', {
-          request: {
-            url: '/jspm_packages/github/components/jquery@2.1.4.js',
-            headers: {
-              accept: 'application/x-es-module */*'
+            response: {
+              errorPassedToNext: /Unterminated String Literal/,
+              statusCode: 500
             }
-          },
-          response: {
-            statusCode: 200,
-            headers: {
-              'Content-Type': /^application\/javascript/
+          });
+        });
+
+        it('should handle commonjs imports of broken assets', function () {
+          return expect(getApp(), 'to yield exchange', {
+            request: {
+              url: '/lib/requireBroken.js',
+              headers: {
+                accept: 'application/x-es-module */*'
+              }
             },
-            body: expect.it('to begin with', '(function() {\nvar define = System.amdDefine;\ndefine(["github:components/jquery@2.1.4/jquery"]')
-          }
-        });
-      });
-
-      it('should return a 304 status code if ETag matches', function () {
-        var app = getApp();
-
-        return expect(app, 'to yield exchange', {
-          request: {
-            url: '/default.js',
-            headers: {
-              accept: 'application/x-es-module */*'
+            response: {
+              statusCode: 200,
+              headers: {
+                'Content-Type': /^application\/javascript/
+              },
+              body: expect.it('to begin with', 'System.registerDynamic(["./broken"]').and('to contain', 'var foo = $__require(\'./broken\');\n  module.exports = {foo: foo};\n')
             }
-          },
-          response: 200
-        })
-        .then(function (context) {
+          });
+        });
+
+        it('should handle jspm modules', function () {
+          return expect(getApp(), 'to yield exchange', {
+            request: {
+              url: '/jspm_packages/github/components/jquery@2.1.4.js',
+              headers: {
+                accept: 'application/x-es-module */*'
+              }
+            },
+            response: {
+              statusCode: 200,
+              headers: {
+                'Content-Type': /^application\/javascript/
+              },
+              body: expect.it('to begin with', '(function() {\nvar define = System.amdDefine;\ndefine(["github:components/jquery@2.1.4/jquery"]')
+            }
+          });
+        });
+
+        it('should return a 304 status code if ETag matches', function () {
+          var app = getApp();
+
           return expect(app, 'to yield exchange', {
             request: {
               url: '/default.js',
               headers: {
-                accept: 'application/x-es-module */*',
-                'If-None-Match': context.res.get('etag')
+                accept: 'application/x-es-module */*'
               }
             },
-            response: 304
+            response: 200
+          })
+          .then(function (context) {
+            return expect(app, 'to yield exchange', {
+              request: {
+                url: '/default.js',
+                headers: {
+                  accept: 'application/x-es-module */*',
+                  'If-None-Match': context.res.get('etag')
+                }
+              },
+              response: 304
+            });
           });
         });
+      });
+
+      describe('with bundling enabled', function () {
+        it('should compile javascript', function () {
+          return expect(getApp({ bundle: true }), 'to yield exchange', {
+            request: {
+              url: '/default.js',
+              headers: {
+                accept: 'application/x-es-module */*'
+              }
+            },
+            response: {
+              statusCode: 200,
+              headers: {
+                'Content-Type': /^application\/javascript/
+              },
+              body: expect.it('to begin with', 'System.registerDynamic("default.js", []').and('to contain', 'console.log(\'hello world\');\n')
+            }
+          });
+        });
+
+        it('should handle commonjs', function () {
+          return expect(getApp({ bundle: true }), 'to yield exchange', {
+            request: {
+              url: '/lib/stringExport.js',
+              headers: {
+                accept: 'application/x-es-module */*'
+              }
+            },
+            response: {
+              statusCode: 200,
+              headers: {
+                'Content-Type': /^application\/javascript/
+              },
+              body: expect.it('to begin with', 'System.registerDynamic("lib/stringExport.js", []').and('to contain', 'module.exports = \'foo\';\n')
+            }
+          });
+        });
+
+        it('should handle commonjs imports', function () {
+          return expect(getApp({ bundle: true }), 'to yield exchange', {
+            request: {
+              url: '/lib/requireWorking.js',
+              headers: {
+                accept: 'application/x-es-module */*'
+              }
+            },
+            response: {
+              statusCode: 200,
+              headers: {
+                'Content-Type': /^application\/javascript/
+              },
+              body: expect.it('to begin with', 'System.registerDynamic("lib/stringExport.js", []')
+                .and('to contain', 'System.registerDynamic("lib/requireWorking.js", ["./stringExport"]')
+                .and('to contain', 'var foo = $__require(\'./stringExport\');\n  module.exports = {foo: foo};\n')
+            }
+          });
+        });
+
+        it('should pass uncompileable errors through to the client', function () {
+          return expect(getApp(), 'to yield exchange', {
+            request: {
+              url: '/lib/broken.js',
+              headers: {
+                accept: 'application/x-es-module */*'
+              }
+            },
+            response: {
+              errorPassedToNext: /Unterminated String Literal/,
+              statusCode: 500
+            }
+          });
+        });
+
+        it('should handle commonjs imports of broken assets', function () {
+          return expect(getApp(), 'to yield exchange', {
+            request: {
+              url: '/lib/requireBroken.js',
+              headers: {
+                accept: 'application/x-es-module */*'
+              }
+            },
+            response: {
+              statusCode: 200,
+              headers: {
+                'Content-Type': /^application\/javascript/
+              },
+              body: expect.it('to begin with', 'System.registerDynamic(["./broken"]').and('to contain', 'var foo = $__require(\'./broken\');\n  module.exports = {foo: foo};\n')
+            }
+          });
+        });
+
+        it('should handle jspm modules', function () {
+          return expect(getApp(), 'to yield exchange', {
+            request: {
+              url: '/jspm_packages/github/components/jquery@2.1.4.js',
+              headers: {
+                accept: 'application/x-es-module */*'
+              }
+            },
+            response: {
+              statusCode: 200,
+              headers: {
+                'Content-Type': /^application\/javascript/
+              },
+              body: expect.it('to begin with', '(function() {\nvar define = System.amdDefine;\ndefine(["github:components/jquery@2.1.4/jquery"]')
+            }
+          });
+        });
+
+        it('should return a 304 status code if ETag matches', function () {
+          var app = getApp();
+
+          return expect(app, 'to yield exchange', {
+            request: {
+              url: '/default.js',
+              headers: {
+                accept: 'application/x-es-module */*'
+              }
+            },
+            response: 200
+          })
+          .then(function (context) {
+            return expect(app, 'to yield exchange', {
+              request: {
+                url: '/default.js',
+                headers: {
+                  accept: 'application/x-es-module */*',
+                  'If-None-Match': context.res.get('etag')
+                }
+              },
+              response: 304
+            });
+          });
+        });
+
       });
 
     });


### PR DESCRIPTION
@gustavnikolaj By testing this I found that the default behaviour in jspm bundle and systemjs bundle differs on `{ normalize: true }`, see https://github.com/Munter/express-systemjs-translate/issues/165#issuecomment-231589080

I'm afraid to merge this because changing the default behaviour might break. Since the path that has changed behaviour is the one you are on in the One.com setup, could you tell me if the setup still works with this branch checked out?

Maybe closes #165 