### PR TITLE
Add tests for using connect as the server instead of express. refs #167

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/Munter/express-systemjs-translate",
   "devDependencies": {
+    "connect": "^3.4.1",
     "coveralls": "^2.11.3",
     "express": "^4.13.1",
     "istanbul": "^0.4.4",

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -3,6 +3,7 @@
 var Path = require('path');
 var fs = require('fs');
 var express = require('express');
+var connect = require('connect');
 var proxyquire = require('proxyquire').noPreserveCache();
 var extend = require('extend');
 var sinon = require('sinon');
@@ -14,7 +15,7 @@ var expect = require('unexpected')
 var root = Path.resolve(__dirname, '../fixtures');
 
 
-var getJspmApp = function (options) {
+var getJspmExpressApp = function (options) {
   return express()
     .use(require('../lib/index')(extend({
       serverRoot: root,
@@ -23,7 +24,27 @@ var getJspmApp = function (options) {
     .use(express.static(root));
 };
 
-var getBuilderApp = function (options) {
+var getJspmConnectApp = function (options) {
+  return connect()
+    .use(require('../lib/index')(extend({
+      serverRoot: root,
+      bundle: false
+    }, options)))
+    .use(express.static(root));
+};
+
+var getBuilderExpressApp = function (options) {
+  return express()
+    .use(proxyquire('../lib/index', { 'jspm': null })(extend({
+      serverRoot: root,
+      baseUrl: root,
+      configFile: 'config.js',
+      bundle: false
+    }, options)))
+    .use(express.static(root));
+};
+
+var getBuilderConnectApp = function (options) {
   return express()
     .use(proxyquire('../lib/index', { 'jspm': null })(extend({
       serverRoot: root,
@@ -574,5 +595,8 @@ function runtests(getApp, description) {
   });
 }
 
-runtests(getJspmApp, 'with Jspm module installed');
-runtests(getBuilderApp, 'with systemjs-builder installed');
+runtests(getJspmExpressApp, 'express with Jspm module installed');
+runtests(getBuilderExpressApp, 'express with systemjs-builder installed');
+
+runtests(getJspmConnectApp, 'connect with Jspm module installed');
+runtests(getBuilderConnectApp, 'connect with systemjs-builder installed');

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -19,7 +19,8 @@ var getJspmExpressApp = function (options) {
   return express()
     .use(require('../lib/index')(extend({
       serverRoot: root,
-      bundle: false
+      bundle: false,
+      watchFiles: false
     }, options)))
     .use(express.static(root));
 };
@@ -28,7 +29,8 @@ var getJspmConnectApp = function (options) {
   return connect()
     .use(require('../lib/index')(extend({
       serverRoot: root,
-      bundle: false
+      bundle: false,
+      watchFiles: false
     }, options)))
     .use(express.static(root));
 };
@@ -39,7 +41,8 @@ var getBuilderExpressApp = function (options) {
       serverRoot: root,
       baseUrl: root,
       configFile: 'config.js',
-      bundle: false
+      bundle: false,
+      watchFiles: false
     }, options)))
     .use(express.static(root));
 };
@@ -50,7 +53,8 @@ var getBuilderConnectApp = function (options) {
       serverRoot: root,
       baseUrl: root,
       configFile: 'config.js',
-      bundle: false
+      bundle: false,
+      watchFiles: false
     }, options)))
     .use(express.static(root));
 };


### PR DESCRIPTION
@papandreou @gustavnikolaj Have any of you seen the message in https://travis-ci.org/Munter/express-systemjs-translate/jobs/144123329#L269-L291 before and have an idea on how we can avoid memory leaks like this in the middleware?