### PR TITLE
escape */ to *\/ in the inlined sourcemap to avoid ending the comment

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -274,7 +274,7 @@ module.exports = function systemJsTranslate(serverRoot, options) {
         var prettyMap = JSON.stringify(map, undefined, 4);
         // log(map.file, 'source map', prettyMap);
         log(map.file, 'source map inlined');
-        result.source += '\n/* DEBUG: ' + map.file + ' source map:\n' + prettyMap + '\n*/\n';
+        result.source += '\n/* DEBUG: ' + map.file + ' source map:\n' + prettyMap.replace(/\*\//g, '*\\/') + '\n*/\n';
       }
     }
 


### PR DESCRIPTION
I had an application that stopped working whenever I added the debug flag in the middleware options.

Turned out it was because said source map included the string `*/` which would cause the browser to throw a SyntaxError when evaluating the prematurely closed comment.

```
SyntaxError: Unexpected token )
```

This is the problematic line: https://github.com/assetgraph/systemjs-asset-plugin/blob/master/asset-plugin.js#L58

My fix here breaks the regex that caused the problem, but I couldn't think of other ways to do this that wouldn't change the outcome. It could also be a comment in the inlined code.