### PR TITLE
Support an array of config files when using systemjs-builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ var app = express()
 app.listen(3000);
 ```
 
+The `configFile` property can also be specified as an array of strings, which
+will be loaded as configuration files in the given order.
+
+This is useful if your configuration is spread across multiple `System.config`
+calls in different scripts.
+
+
 SystemJS Configuration
 ----------------------
 
@@ -74,10 +81,10 @@ System.config({
 });
 ```
 
-Midleware Configuration
------------------------
+Middleware Configuration
+------------------------
 
-The translate middelware takes a few options to adapt to your project setup. This is the full configuration API:
+The translate middleware takes a few options to adapt to your project setup. This is the full configuration API:
 
 ```js
 var translate = require('express-systemjs-translate');

--- a/fixtures/config2.js
+++ b/fixtures/config2.js
@@ -1,0 +1,5 @@
+System.config({
+  paths: {
+    'default2.js': 'lib/stringExport.js'
+  }
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,7 +97,7 @@ module.exports = function systemJsTranslate(serverRoot, options) {
     log(chalk.yellow('WARNING! You are using the `depCache` option. This will most likely slow down your load performance considerably'));
   }
 
-  var absoluteConfigUrl;
+  var absoluteConfigUrls;
   var hasJspm = false;
 
   try {
@@ -106,7 +106,7 @@ module.exports = function systemJsTranslate(serverRoot, options) {
 
     builder = new Builder();
 
-    absoluteConfigUrl = parentRequire('jspm/lib/config').pjson.configFile;
+    absoluteConfigUrls = [parentRequire('jspm/lib/config').pjson.configFile];
 
     hasJspm = true;
   } catch (err) {
@@ -114,9 +114,13 @@ module.exports = function systemJsTranslate(serverRoot, options) {
     try {
       Builder = parentRequire('systemjs-builder');
 
-      absoluteConfigUrl = Path.resolve(process.cwd(), options.configFile);
-
-      builder = new Builder(options.baseUrl, absoluteConfigUrl);
+      absoluteConfigUrls = (Array.isArray(options.configFile) ? options.configFile : [options.configFile]).map(function (configFile) {
+        return Path.resolve(process.cwd(), configFile);
+      });
+      builder = new Builder(options.baseUrl, absoluteConfigUrls[0]);
+      absoluteConfigUrls.slice(1).forEach(function (absoluteConfigUrl) {
+        builder.loadConfigSync(absoluteConfigUrl);
+      });
     } catch (err) {
       if (err.code === 'MODULE_NOT_FOUND') {
         throw new Error('express-systemjs-translate: jspm and systemjs-builder packages not found. You need at least one of these packages installed');
@@ -128,7 +132,9 @@ module.exports = function systemJsTranslate(serverRoot, options) {
 
   var absoluteServerRoot = Path.resolve(process.cwd(), serverRoot);
   var baseURLPath = fromFileURL(builder.loader.baseURL);
-  var rootRelativeConfigUrl = Path.relative(absoluteServerRoot, absoluteConfigUrl);
+  var rootRelativeConfigUrls = absoluteConfigUrls.map(function (absoluteConfigUrl) {
+    return Path.relative(absoluteServerRoot, absoluteConfigUrl);
+  });
   var rootRelativeBaseUrlPath = Path.relative(absoluteServerRoot, baseURLPath);
 
   if (rootRelativeBaseUrlPath.indexOf('..') === 0) {
@@ -147,13 +153,15 @@ module.exports = function systemJsTranslate(serverRoot, options) {
     }
   }
 
-  if (Path.relative(baseURLPath, absoluteConfigUrl).indexOf('..') === 0) {
-    throw new Error([
-      'express-systemjs-translate: Configuration error. SystemJS configuration file must be within the SystemJS baseURL.',
-      'baseUrl: ' + baseURLPath,
-      'configFile: ' + absoluteConfigUrl
-    ].join('\n\t'));
-  }
+  absoluteConfigUrls.forEach(function (absoluteConfigUrl) {
+    if (Path.relative(baseURLPath, absoluteConfigUrl).indexOf('..') === 0) {
+      throw new Error([
+        'express-systemjs-translate: Configuration error. SystemJS configuration file must be within the SystemJS baseURL.',
+        'baseUrl: ' + baseURLPath,
+        'configFile: ' + absoluteConfigUrl
+      ].join('\n\t'));
+    }
+  });
 
   builder.config({
     rootURL: absoluteServerRoot
@@ -292,21 +300,24 @@ module.exports = function systemJsTranslate(serverRoot, options) {
 
     // Intercept requests for the SystemJS config file to augment is with depCache information
     if (options.depCache) {
-      if (req.path === ('/' + rootRelativeConfigUrl)) {
-        fs.readFile(absoluteConfigUrl, 'utf8', function (err, configString) {
-          var response = [
-            configString,
-            'SystemJS.config({ depCache: ' + JSON.stringify(depCache, undefined, 2) + ' })'
-          ].join('\n\n');
+      if (rootRelativeConfigUrls.some(function (rootRelativeConfigUrl, i) {
+        if (req.path === '/' + rootRelativeConfigUrl) {
+          fs.readFile(absoluteConfigUrls[i], 'utf8', function (err, configString) {
+            var response = [
+              configString,
+              'SystemJS.config({ depCache: ' + JSON.stringify(depCache, undefined, 2) + ' })'
+            ].join('\n\n');
 
-          res.set({
-            'Content-Type': 'application/javascript; charset=UTF-8'
+            res.set({
+              'Content-Type': 'application/javascript; charset=UTF-8'
+            });
+            res.end(response);
+
+            log(time(), 'Serve depCache augmented SystemJS config file');
           });
-          res.end(response);
-
-          log(time(), 'Serve depCache augmented SystemJS config file');
-        });
-
+          return true;
+        }
+      })) {
         return;
       }
     }


### PR DESCRIPTION
This is necessary when splitting up the configuration so that assetgraph-builder can omit the builder-specific config from the production build, as implemented in https://github.com/assetgraph/assetgraph/commit/a4fc21f83755bd419dc9caa0e604af472faf17d9