### PR TITLE
Provide browserRootURL from request

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -340,10 +340,10 @@ module.exports = function systemJsTranslate(serverRoot, options) {
       var builderPromise;
 
       if (options.bundle) {
-        builderPromise = builder.bundle(fileName, extend(options.buildFlags, { config: { browserRootURL: 'http://' + req.headers.host } }));
+        builderPromise = builder.bundle(fileName, extend(options.buildFlags, { config: { browserRootURL: req.protocol + '://' + req.headers.host } }));
       } else {
         // If source maps are wanted, also put in source files content
-        builderPromise = builder.compile(fileName, extend(options.buildFlags, { sourceMapContents: !!options.sourceMap, config: { browserRootURL: 'http://' + req.headers.host } }));
+        builderPromise = builder.compile(fileName, extend(options.buildFlags, { sourceMapContents: !!options.sourceMap, config: { browserRootURL: req.protocol + '://' + req.headers.host } }));
       }
 
       builderPromise

--- a/lib/index.js
+++ b/lib/index.js
@@ -340,10 +340,10 @@ module.exports = function systemJsTranslate(serverRoot, options) {
       var builderPromise;
 
       if (options.bundle) {
-        builderPromise = builder.bundle(fileName, options.buildFlags);
+        builderPromise = builder.bundle(fileName, extend(options.buildFlags, { config: { browserRootURL: 'http://' + req.headers.host } }));
       } else {
         // If source maps are wanted, also put in source files content
-        builderPromise = builder.compile(fileName, extend(options.buildFlags, { sourceMapContents: !!options.sourceMap }));
+        builderPromise = builder.compile(fileName, extend(options.buildFlags, { sourceMapContents: !!options.sourceMap, config: { browserRootURL: 'http://' + req.headers.host } }));
       }
 
       builderPromise


### PR DESCRIPTION
This effectively provides the hostname information to SystemJS plugins, which was necessary for CSS source maps to work out correctly using blob URLs at the top-level.