### PR TITLE
resolve symlinks before watching files

### DIFF
--- a/fixtures/maybeRealPath/brokenSymlink.txt
+++ b/fixtures/maybeRealPath/brokenSymlink.txt
@@ -1,0 +1,1 @@
+nonExistant.txt

--- a/fixtures/maybeRealPath/brokenSymlink.txt
+++ b/fixtures/maybeRealPath/brokenSymlink.txt
@@ -1,1 +1,1 @@
-nonExistant.txt
+nonExistent.txt

--- a/fixtures/maybeRealPath/symlink.txt
+++ b/fixtures/maybeRealPath/symlink.txt
@@ -1,0 +1,1 @@
+file.txt

--- a/lib/index.js
+++ b/lib/index.js
@@ -219,11 +219,22 @@ module.exports = function systemJsTranslate(serverRoot, options) {
     });
   }
 
+  function maybeRealPath(path) {
+    try {
+      return fs.realpathSync(path);
+    } catch (e) {
+      if (e.code === 'ENOENT') {
+        return path;
+      }
+      throw e;
+    }
+  }
+
   function watchResults(options, fileName, result) {
     // builder cache invalidation based on file watching
     if (options.watchFiles) {
       var filesToWatch = !options.bundle ? [fileName] : result.modules.map(function (moduleName) {
-        return Path.join(baseURLPath, result.tree[moduleName].path);
+        return maybeRealPath(Path.join(baseURLPath, result.tree[moduleName].path));
       });
 
       watchFiles(filesToWatch);

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,7 @@ var chalk = require('chalk');
 var difference = require('lodash.difference');
 var inlineSourcemapComment = require('inline-source-map-comment');
 var parentRequire = require('parent-require');
+var maybeRealPath = require('./maybeRealPath');
 
 var Builder;
 
@@ -217,17 +218,6 @@ module.exports = function systemJsTranslate(serverRoot, options) {
         }
       }
     });
-  }
-
-  function maybeRealPath(path) {
-    try {
-      return fs.realpathSync(path);
-    } catch (e) {
-      if (e.code === 'ENOENT') {
-        return path;
-      }
-      throw e;
-    }
   }
 
   function watchResults(options, fileName, result) {

--- a/lib/maybeRealPath.js
+++ b/lib/maybeRealPath.js
@@ -1,0 +1,12 @@
+var fs = require('fs');
+
+module.exports = function maybeRealPath(path) {
+  try {
+    return fs.realpathSync(path);
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      return path;
+    }
+    throw e;
+  }
+};

--- a/test/maybeRealPath-test.js
+++ b/test/maybeRealPath-test.js
@@ -1,0 +1,48 @@
+var path = require('path');
+var proxyquire = require('proxyquire');
+var expect = require('unexpected')
+  .clone()
+  .addAssertion('<string> to resolve to <string>', function (expect, subject, value) {
+    return expect(subject, 'to equal', value);
+  });
+var maybeRealPath = require('../lib/maybeRealPath');
+
+function fixturesPath(name) {
+  return path.resolve(__dirname, '../fixtures/maybeRealPath', name);
+}
+
+describe('maybeRealPath', function () {
+  it('should return the original path to an existing file', function () {
+    return expect(maybeRealPath(fixturesPath('file.txt')), 'to resolve to', fixturesPath('file.txt'));
+  });
+  it('should resolve a symlink to the original path', function () {
+    return expect(maybeRealPath(fixturesPath('symlink.txt')), 'to resolve to', fixturesPath('file.txt'));
+  });
+  it('should return the path to the symlink when resolving a broken symlink', function () {
+    return expect(maybeRealPath(fixturesPath('brokenSymlink.txt')), 'to resolve to', fixturesPath('brokenSymlink.txt'));
+  });
+  it('should swallow ENOENT exceptions and return the input instead', function () {
+    var maybeRealPath = proxyquire('../lib/maybeRealPath', {
+      fs: {
+        realpathSync: function () {
+          var err = new Error();
+          err.code = 'ENOENT';
+          throw err;
+        }
+      }
+    });
+    return expect(maybeRealPath('foobar'), 'to equal', 'foobar');
+  });
+  it('should not swallow exceptions other than ENOENT', function () {
+    var maybeRealPath = proxyquire('../lib/maybeRealPath', {
+      fs: {
+        realpathSync: function () {
+          throw new Error('FOOBAR');
+        }
+      }
+    });
+    return expect(function () {
+      maybeRealPath('foobar');
+    }, 'to throw', 'FOOBAR');
+  });
+});

--- a/test/maybeRealPath-test.js
+++ b/test/maybeRealPath-test.js
@@ -1,25 +1,28 @@
 var path = require('path');
 var proxyquire = require('proxyquire');
-var expect = require('unexpected')
-  .clone()
-  .addAssertion('<string> to resolve to <string>', function (expect, subject, value) {
-    return expect(subject, 'to equal', value);
-  });
-var maybeRealPath = require('../lib/maybeRealPath');
 
 function fixturesPath(name) {
   return path.resolve(__dirname, '../fixtures/maybeRealPath', name);
 }
 
+
+var expect = require('unexpected')
+  .clone()
+  .addAssertion('<string> to resolve to <string>', function (expect, subject, value) {
+    return expect(maybeRealPath(fixturesPath(subject)), 'to equal', fixturesPath(value));
+  });
+var maybeRealPath = require('../lib/maybeRealPath');
+
+
 describe('maybeRealPath', function () {
   it('should return the original path to an existing file', function () {
-    return expect(maybeRealPath(fixturesPath('file.txt')), 'to resolve to', fixturesPath('file.txt'));
+    return expect('file.txt', 'to resolve to', 'file.txt');
   });
   it('should resolve a symlink to the original path', function () {
-    return expect(maybeRealPath(fixturesPath('symlink.txt')), 'to resolve to', fixturesPath('file.txt'));
+    return expect('symlink.txt', 'to resolve to', 'file.txt');
   });
   it('should return the path to the symlink when resolving a broken symlink', function () {
-    return expect(maybeRealPath(fixturesPath('brokenSymlink.txt')), 'to resolve to', fixturesPath('brokenSymlink.txt'));
+    return expect('brokenSymlink.txt', 'to resolve to', 'brokenSymlink.txt');
   });
   it('should swallow ENOENT exceptions and return the input instead', function () {
     var maybeRealPath = proxyquire('../lib/maybeRealPath', {


### PR DESCRIPTION
We had a problem where files from an npm linked package wasn't triggering rebuilds properly. This fixes it so that the server will watch the real files and not the symlinks.