### PR TITLE
manual fix for error found when updating eslint-config-onelint to 2.0.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -305,6 +305,9 @@ module.exports = function systemJsTranslate(serverRoot, options) {
       if (rootRelativeConfigUrls.some(function (rootRelativeConfigUrl, i) {
         if (req.path === '/' + rootRelativeConfigUrl) {
           fs.readFile(absoluteConfigUrls[i], 'utf8', function (err, configString) {
+            if (err) {
+              return next(err);
+            }
             var response = [
               configString,
               'SystemJS.config({ depCache: ' + JSON.stringify(depCache, undefined, 2) + ' })'

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "connect": "^3.4.1",
     "coveralls": "^2.11.11",
     "eslint": "^3.8.1",
-    "eslint-config-onelint": "1.2.0",
+    "eslint-config-onelint": "2.0.0",
     "express": "^4.13.1",
     "istanbul": "^0.4.4",
     "jspm": "^0.16.42",


### PR DESCRIPTION
Upgrading `eslint-config-onelint` to 2.0.0 found an unhandled err in a callback.

I assume that we just want to pass it to next here. Would like at least another set of eyes before merging :-)